### PR TITLE
 Update node.js 16 actions to node.js 20

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -11,9 +11,9 @@ jobs:
   PlatformIO:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Cache pip
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -25,7 +25,7 @@ jobs:
         path: ~/.platformio
         key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
     - name: Install PlatformIO


### PR DESCRIPTION
Kia ora, hope you're having an amazing day! I just tried to use Github actions to build a copy of HyperSPIand it failed due to Github deprecating node.js 16, these changes got it working for me.
Thank you for your incredible work, HyperHDR is an amazing bit of software that I use practically every day!