### PR TITLE
Add support for Adafruit ItsyBitsy RP2040 and Feather RP2040 Scorpio

### DIFF
--- a/.github/workflows/push-master-pico.yml
+++ b/.github/workflows/push-master-pico.yml
@@ -79,11 +79,11 @@ jobs:
         rm *.*
         rm ../HyperSerialPico/firmware/*
         echo "Neopixel is using GPIO14(OUTPUT_DATA_PIN) on output D5." > ../HyperSerialPico/firmware/Firmware_for_Adafruit_ItsyBitsy_RP2040.txt
-        echo "SPI MOSI is GPIO27 (A1)" >> ../HyperSerialPico/firmware/Firmware_for_Adafruit_ItsyBitsy_RP2040.txt
+        echo "SPI MOSI->MISO is GPIO28 (A2)" >> ../HyperSerialPico/firmware/Firmware_for_Adafruit_ItsyBitsy_RP2040.txt
         echo "SPI SCK is GPIO26 (A0)" >> ../HyperSerialPico/firmware/Firmware_for_Adafruit_ItsyBitsy_RP2040.txt
         echo "SPI CHIP_SELECT is GPIO29 (A3)" >> ../HyperSerialPico/firmware/Firmware_for_Adafruit_ItsyBitsy_RP2040.txt
         echo "SPI interface is spi1" >> ../HyperSerialPico/firmware/Firmware_for_Adafruit_ItsyBitsy_RP2040.txt
-        cmake -DOVERRIDE_DATA_PIN=14 -DOVERRIDE_SPI_DATA_PIN=27 -DOVERRIDE_SPI_CLOCK_PIN=26 -DOVERRIDE_SPI_CHIP_SELECT=29 -DOVERRIDE_SPI_INTERFACE=spi1 -DCMAKE_BUILD_TYPE=Release ..
+        cmake -DOVERRIDE_DATA_PIN=14 -DOVERRIDE_SPI_DATA_PIN=28 -DOVERRIDE_SPI_CLOCK_PIN=26 -DOVERRIDE_SPI_CHIP_SELECT=29 -DOVERRIDE_SPI_INTERFACE=spi1 -DCMAKE_BUILD_TYPE=Release ..
         cmake --build .
         zip -j ../HyperSerialPico/firmware/Adafruit_ItsyBitsy_RP2040.zip ../HyperSerialPico/firmware/*
 

--- a/.github/workflows/push-master-pico.yml
+++ b/.github/workflows/push-master-pico.yml
@@ -53,7 +53,11 @@ jobs:
         rm *.*
         rm ../HyperSerialPico/firmware/*
         echo "Neopixel is using GPIO16(OUTPUT_DATA_PIN) on output 0." > ../HyperSerialPico/firmware/Firmware_for_Adafruit_Feather_RP2040_Scorpio.txt
-        cmake -DOVERRIDE_DATA_PIN=16 -DCMAKE_BUILD_TYPE=Release ..
+        echo "SPI MOSI->MISO is GPIO28 (A2)" >> ../HyperSerialPico/firmware/Firmware_for_Adafruit_Feather_RP2040_Scorpio.txt
+        echo "SPI SCK is GPIO26 (A0)" >> ../HyperSerialPico/firmware/Firmware_for_Adafruit_Feather_RP2040_Scorpio.txt
+        echo "SPI CHIP_SELECT is GPIO29 (A3)" >> ../HyperSerialPico/firmware/Firmware_for_Adafruit_Feather_RP2040_Scorpio.txt
+        echo "SPI interface is spi1" >> ../HyperSerialPico/firmware/Firmware_for_Adafruit_Feather_RP2040_Scorpio.txt
+        cmake -DOVERRIDE_DATA_PIN=16 -DOVERRIDE_SPI_DATA_PIN=28 -DOVERRIDE_SPI_CLOCK_PIN=26 -DOVERRIDE_SPI_CHIP_SELECT=29 -DOVERRIDE_SPI_INTERFACE=spi1 -DCMAKE_BUILD_TYPE=Release ..
         cmake --build .
         zip -j ../HyperSerialPico/firmware/Adafruit_Feather_RP2040_Scorpio.zip ../HyperSerialPico/firmware/*
 

--- a/.github/workflows/push-master-pico.yml
+++ b/.github/workflows/push-master-pico.yml
@@ -14,7 +14,7 @@ jobs:
       run:
         working-directory: ./rp2040
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -30,21 +30,22 @@ jobs:
         cd build
         cmake ..
         cmake --build . --config Release
+        zip -j ../HyperSerialPico/firmware/hyperspi_pico_rp2040.zip ../HyperSerialPico/firmware/*.uf2
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       name: Upload artifacts (commit)
       if: (startsWith(github.event.ref, 'refs/tags') != true)
       with:
         path: |
-          rp2040/HyperSerialPico/firmware/*.uf2
+          rp2040/HyperSerialPico/firmware/*.zip
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       name: Upload artifacts (release)
       if: startsWith(github.ref, 'refs/tags/')
       with:
         name: firmware-release
         path: |
-          rp2040/HyperSerialPico/firmware/*.uf2
+          rp2040/HyperSerialPico/firmware/*.zip
 
     - name: Build packages for Adafruit Feather RP2040 Scorpio
       shell: bash
@@ -61,14 +62,14 @@ jobs:
         cmake --build .
         zip -j ../HyperSerialPico/firmware/Adafruit_Feather_RP2040_Scorpio.zip ../HyperSerialPico/firmware/*
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       name: Upload artifacts (Adafruit_Feather)
       if: (startsWith(github.event.ref, 'refs/tags') != true)      
       with:
         path: |
           rp2040/HyperSerialPico/firmware/*.zip
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       name: Upload artifacts (release for Adafruit_Feather)
       if: startsWith(github.ref, 'refs/tags/')
       with:
@@ -91,14 +92,14 @@ jobs:
         cmake --build .
         zip -j ../HyperSerialPico/firmware/Adafruit_ItsyBitsy_RP2040.zip ../HyperSerialPico/firmware/*
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       name: Upload artifacts (Adafruit_ItsyBitsy)
       if: (startsWith(github.event.ref, 'refs/tags') != true)      
       with:
         path: |
           rp2040/HyperSerialPico/firmware/*.zip
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       name: Upload artifacts (release for Adafruit_ItsyBitsy)
       if: startsWith(github.ref, 'refs/tags/')
       with:
@@ -129,7 +130,7 @@ jobs:
         if: contains(env.VERSION, 'alpha') || contains(env.VERSION, 'beta')
         run: echo "preRelease=true" >> $GITHUB_ENV
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: firmware-release
 

--- a/.github/workflows/push-master-pico.yml
+++ b/.github/workflows/push-master-pico.yml
@@ -52,7 +52,7 @@ jobs:
         cd build
         rm *.*
         rm ../HyperSerialPico/firmware/*
-        echo "Neopixel is using GPIO16(OUTPUT_DATA_PIN) on output 0." > ../HyperSerialPico/firmware/Firmwares_for_Adafruit_Feather_RP2040_Scorpio.txt
+        echo "Neopixel is using GPIO16(OUTPUT_DATA_PIN) on output 0." > ../HyperSerialPico/firmware/Firmware_for_Adafruit_Feather_RP2040_Scorpio.txt
         cmake -DOVERRIDE_DATA_PIN=16 -DCMAKE_BUILD_TYPE=Release ..
         cmake --build .
         zip -j ../HyperSerialPico/firmware/Adafruit_Feather_RP2040_Scorpio.zip ../HyperSerialPico/firmware/*
@@ -66,6 +66,36 @@ jobs:
 
     - uses: actions/upload-artifact@v3
       name: Upload artifacts (release for Adafruit_Feather)
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        name: firmware-release
+        path: |
+          rp2040/HyperSerialPico/firmware/*.zip
+
+    - name: Build packages for Adafruit ItsyBitsy RP2040
+      shell: bash
+      run: |
+        cd build
+        rm *.*
+        rm ../HyperSerialPico/firmware/*
+        echo "Neopixel is using GPIO14(OUTPUT_DATA_PIN) on output D5." > ../HyperSerialPico/firmware/Firmware_for_Adafruit_ItsyBitsy_RP2040.txt
+        echo "SPI MOSI is GPIO27 (A1)" >> ../HyperSerialPico/firmware/Firmware_for_Adafruit_ItsyBitsy_RP2040.txt
+        echo "SPI SCK is GPIO26 (A0)" >> ../HyperSerialPico/firmware/Firmware_for_Adafruit_ItsyBitsy_RP2040.txt
+        echo "SPI CHIP_SELECT is GPIO29 (A3)" >> ../HyperSerialPico/firmware/Firmware_for_Adafruit_ItsyBitsy_RP2040.txt
+        echo "SPI interface is spi1" >> ../HyperSerialPico/firmware/Firmware_for_Adafruit_ItsyBitsy_RP2040.txt
+        cmake -DOVERRIDE_DATA_PIN=14 -DOVERRIDE_SPI_DATA_PIN=27 -DOVERRIDE_SPI_CLOCK_PIN=26 -DOVERRIDE_SPI_CHIP_SELECT=29 -DOVERRIDE_SPI_INTERFACE=spi1 -DCMAKE_BUILD_TYPE=Release ..
+        cmake --build .
+        zip -j ../HyperSerialPico/firmware/Adafruit_ItsyBitsy_RP2040.zip ../HyperSerialPico/firmware/*
+
+    - uses: actions/upload-artifact@v3
+      name: Upload artifacts (Adafruit_ItsyBitsy)
+      if: (startsWith(github.event.ref, 'refs/tags') != true)      
+      with:
+        path: |
+          rp2040/HyperSerialPico/firmware/*.zip
+
+    - uses: actions/upload-artifact@v3
+      name: Upload artifacts (release for Adafruit_ItsyBitsy)
       if: startsWith(github.ref, 'refs/tags/')
       with:
         name: firmware-release

--- a/.github/workflows/push-master-pico.yml
+++ b/.github/workflows/push-master-pico.yml
@@ -36,6 +36,7 @@ jobs:
       name: Upload artifacts (commit)
       if: (startsWith(github.event.ref, 'refs/tags') != true)
       with:
+        name: commit-artifact-pico
         path: |
           rp2040/HyperSerialPico/firmware/*.zip
 
@@ -43,7 +44,7 @@ jobs:
       name: Upload artifacts (release)
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        name: firmware-release
+        name: release-artifact-pico
         path: |
           rp2040/HyperSerialPico/firmware/*.zip
 
@@ -66,6 +67,7 @@ jobs:
       name: Upload artifacts (Adafruit_Feather)
       if: (startsWith(github.event.ref, 'refs/tags') != true)      
       with:
+        name: commit-artifact-Adafruit_Feather
         path: |
           rp2040/HyperSerialPico/firmware/*.zip
 
@@ -73,7 +75,7 @@ jobs:
       name: Upload artifacts (release for Adafruit_Feather)
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        name: firmware-release
+        name: release-artifact-Adafruit_Feather
         path: |
           rp2040/HyperSerialPico/firmware/*.zip
 
@@ -96,6 +98,7 @@ jobs:
       name: Upload artifacts (Adafruit_ItsyBitsy)
       if: (startsWith(github.event.ref, 'refs/tags') != true)      
       with:
+        name: commit-artifact-Adafruit_ItsyBitsy
         path: |
           rp2040/HyperSerialPico/firmware/*.zip
 
@@ -103,7 +106,7 @@ jobs:
       name: Upload artifacts (release for Adafruit_ItsyBitsy)
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        name: firmware-release
+        name: release-artifact-Adafruit_ItsyBitsy
         path: |
           rp2040/HyperSerialPico/firmware/*.zip
 
@@ -130,9 +133,12 @@ jobs:
         if: contains(env.VERSION, 'alpha') || contains(env.VERSION, 'beta')
         run: echo "preRelease=true" >> $GITHUB_ENV
 
-      - uses: actions/download-artifact@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
         with:
-          name: firmware-release
+          path: artifacts
+          pattern: release-artifact-*
+          merge-multiple: true
 
       # create draft release and upload artifacts
       - name: Create draft release
@@ -140,9 +146,7 @@ jobs:
         with:
           name: HyperSPI ${{ env.VERSION }}
           tag_name: ${{ env.TAG }}
-          files: |
-            *.uf2
-            *.zip
+          files: "artifacts/**"
           draft: true
           prerelease: ${{ env.preRelease }}
         env:

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -38,15 +38,16 @@ jobs:
         zip -j .pio/build/recovery_firmware.zip .pio/build/*.factory.bin
         rm -f .pio/build/*.factory.bin
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       name: Upload artifacts (commit)
       if: (startsWith(github.event.ref, 'refs/tags') != true)
       with:
+        name: firmware
         path: |
           .pio/build/*.bin
           .pio/build/recovery_firmware.zip
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       name: Upload artifacts (release)
       if: startsWith(github.ref, 'refs/tags/')
       with:
@@ -76,7 +77,7 @@ jobs:
         if: contains(env.VERSION, 'alpha') || contains(env.VERSION, 'beta')
         run: echo "preRelease=true" >> $GITHUB_ENV
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: firmware-release
 

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -20,7 +20,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
     - name: Cache PlatformIO
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.platformio
         key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
@@ -42,7 +42,7 @@ jobs:
       name: Upload artifacts (commit)
       if: (startsWith(github.event.ref, 'refs/tags') != true)
       with:
-        name: firmware
+        name: firmware-archive
         path: |
           .pio/build/*.bin
           .pio/build/recovery_firmware.zip

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ As you can also notice, the pinout of the SPI0 interface is identical for the en
 
 ## Default pinout (can be changed for esp32, esp32-s2 and rp2040 Pico)
   
-|    PINOUT   |  ESP8266  |   ESP32   | ESP32-S2 | Pico (rp2040) | Adafruit rp2040<br/>Scorpio & ItsyBitsy
+|    PINOUT   |  ESP8266  |   ESP32   | ESP32-S2 | Pico (rp2040) | Adafruit rp2040<br/>Scorpio / ItsyBitsy
 |-------------|-----------|-----------|-----------|-----------|-----------|
 | Clock (SCK) | GPIO 14   | GPIO 18   | GPIO 7    | GPIO 2    | GPIO 26 (A0) |
 | Data (MOSI) | GPIO 13   | GPIO 23   | GPIO 11   | GPIO 4    | GPIO 28 (A2) |
@@ -114,7 +114,7 @@ For **RGB LED strip** like WS8212b or RGB SK6812 variant choose: *hyperspi_..._W
 
 It's very easy and you don't need any special flasher.  
 
-Use firmware from the `PicoRp2040Boards.zip` archive. Adafruit boards have their own custom firmware package inside the archive: `Adafruit_ItsyBitsy_RP2040.zip` and `Adafruit_Feather_RP2040_Scorpio.zip`
+Use firmware from the `hyperspi_pico_rp2040.zip` archive. Adafruit boards have their own custom firmware package inside the archive: `Adafruit_ItsyBitsy_RP2040.zip` and `Adafruit_Feather_RP2040_Scorpio.zip`
 
 Put your Pico board into DFU mode:  
 * If your Pico board has only one button (`boot`) then press & hold it and connect the board to the USB port. Then you can release the button.
@@ -127,7 +127,7 @@ The Pico will reset automaticly after the upload and after few seconds it will b
 
 **In HyperHDR `Image Processing→Smoothing→Update frequency` you should do not exceed the maximum capacity of the device. Read more here: [testing performance](https://github.com/awawa-dev/HyperSPI#performance-output)**
 
-Select esp8266 protocol for ESP proprietary SPI protocol, esp32 for ESP32 boards, `rp2040 (Pico)` for Pico boards or 'standard' for other devices.    
+Select `esp8266` protocol for ESP proprietary SPI protocol, `esp32` for ESP32 boards, `rp2040 (Pico)` for Pico boards or `standard` for other devices.    
 Make sure you set "Refresh time" to zero, "Baudrate" should be set to high but realistic value like ```25 000 000```.  
 Enabling "White channel calibration" is optional, if you want to fine tune the white channel balance of your sk6812 RGBW LED strip.
   

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Raspberry Pi acts as a master, ESP8266/ESP32/ESP32-S2/rp2040(Raspberry Pi Pico) 
 - SPI doesn't have any data integration check. But AWA protocol does have one
 - you don't need to have 2Mb capable serial port on your ESP board
 - SPI transmission is much lighter than serial communication
-- There is a hardware limitation for the Rpi current design...even if you connect your grabber using USB2.0 mode, working serial port driver (used by Adalight) results in quite a large overall USB transfer. So we can replace Adalight with a pure SPI data transfer as an alternative
+- There is a hardware limitation for the Rpi current design...even if you connect your grabber using USB2.0 mode, working serial port driver (used by Adalight) results in quite a large drop in overall USB transfer. So we can replace Adalight with a pure SPI data transfer as an alternative
 - I needed it and I was able to implemented it 😉
 
 # Hardware connection  

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ As you can also notice, the pinout of the SPI0 interface is identical for the en
     <td><img src="https://user-images.githubusercontent.com/69086569/216763154-ca4aa8fa-5855-43c1-86c2-d401010de675.png"/></td>
     <td><img src="https://user-images.githubusercontent.com/69086569/231207350-a670bfea-a96d-4d21-9e8f-f2ca027105da.png"/></td>
   </tr>
+  <tr>
+    <td><img src="https://github.com/awawa-dev/HyperSPI/assets/69086569/170f5718-df88-4ef2-9ed8-7d92d913aeec"/></td>
+    <td><img src="https://github.com/awawa-dev/HyperSPI/assets/69086569/9235c689-062e-4c62-b632-8c506b0e2e97"/></td>
+  </tr>
 </table>
 
 # Example of supported boards

--- a/README.md
+++ b/README.md
@@ -137,27 +137,19 @@ Enabling "White channel calibration" is optional, if you want to fine tune the w
 
 ## ESP32 & ESP32-S2 parallel multi-segment mode
 
-| LED strip / Device                                                                      | ESP32 MH-ET LIVE mini<br/>HyperSPI v9 |  ESP32-S2 Lolin mini<br/>HyperSPI v9 |
+| sk6812 LED strip / Device                                                                      | ESP32 MH-ET LIVE mini<br/>HyperSPI v9 |  ESP32-S2 Lolin mini<br/>HyperSPI v9 |
 |-----------------------------------------------------------------------------------------|-----------------------|----------------------|
-| 300LEDs sk6812<br>Refresh rate/continues output=100Hz<br>SECOND_SEGMENT_START_INDEX=150 |          100          |          100         |
-| 600LEDs sk6812<br>Refresh rate/continues output=83Hz<br>SECOND_SEGMENT_START_INDEX=300  |           83          |           83         |
-| 900LEDs sk6812<br>Refresh rate/continues output=55Hz <br>SECOND_SEGMENT_START_INDEX=450 |         54-55         |           55         |
+| 300 RGBW LEDs<br>Refresh rate/continues output=100Hz<br>SECOND_SEGMENT_START_INDEX=150 |          100          |          100         |
+| 600 RGBW LEDs<br>Refresh rate/continues output=83Hz<br>SECOND_SEGMENT_START_INDEX=300  |           83          |           83         |
+| 900 RGBW LEDs<br>Refresh rate/continues output=55Hz <br>SECOND_SEGMENT_START_INDEX=450 |         54-55         |           55         |
 
-## ESP32
+## SP8266 / ESP32
 
-| LED strip / Device                             | ESP32 MH ET Live<br/>HyperSPI v9 | ESP32-S2 Lolin mini<br/>HyperSPI v9 |
-|------------------------------------------------|-----------------|--------------------|
-| 300LEDs RGBW<br>Refresh rate/continues output=83Hz  |        83       |          83        |
-| 600LEDs RGBW<br>Refresh rate/continues output=43Hz  |      42-43      |          42        |
-| 900LEDs RGBW<br>Refresh rate/continues output=28Hz  |       28        |          28        |
-
-## ESP8266
-
-| LED strip / Device                             | ESP8266 Wemos D1 Pro<br/>HyperSPI v9 |
-|------------------------------------------------|---------------------|
-| 300LEDs RGBW<br>Refresh rate/continues output=70Hz  |          70         |
-| 600LEDs RGBW<br>Refresh rate/continues output=33Hz  |          33         |
-| 900LEDs RGBW<br>Refresh rate/continues output=22Hz  |          22         |
+| sk6812 LED strip / Device                             | ESP32 MH ET Live<br/>HyperSPI v9 | ESP32-S2 Lolin mini<br/>HyperSPI v9 | ESP8266 Wemos D1 Pro<br/>HyperSPI v9 |
+|------------------------------------------------|-----------------|--------------------|---------------------|
+| 300 RGBW LEDs<br>continues output=83/70Hz  |        83       |          83        |          70         |
+| 600 RGBW LEDs<br>continues output=43/33Hz  |      42-43      |          42        |          33         |
+| 900 RGBW LEDs<br>continues output=28/22Hz  |       28        |          28        |          22         |
 
 # Compiling
 
@@ -208,7 +200,7 @@ build_flags = -DNEOPIXEL_RGB -DDATA_PIN=2 ${env.build_flags} -DSECOND_SEGMENT_ST
 Implementation example:
 - The diagram of the board for WS2812b/SK6812 including ESP32 and the SN74AHCT125N 74AHCT125 [level shifter](https://github.com/awawa-dev/HyperHDR/wiki/Level-Shifter).
 
-# Pico rp2040
+## Pico rp2040
 
 Edit ```rp2040\CMakeLists.txt``` file and recompile the project.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ As you can also notice, the pinout of the SPI0 interface is identical for the en
   </tr>
   <tr>
     <td colspan="2"><img src="https://github.com/awawa-dev/HyperSPI/assets/69086569/7f24f87e-f7e0-43f3-a568-39d0f6beced1"/></td>
-  </tr>  
+  </tr>
+  <tr>
+    <td><img src="https://github.com/awawa-dev/HyperSPI/assets/69086569/170f5718-df88-4ef2-9ed8-7d92d913aeec"/></td>
+    <td><img src="https://github.com/awawa-dev/HyperSPI/assets/69086569/9235c689-062e-4c62-b632-8c506b0e2e97"/></td>
+  </tr>
   <tr>
     <td colspan="2"><p align="center">or if you prefer ESP32/ESP32-S2/Esp8266</p></td>
   </tr>
@@ -44,11 +48,7 @@ As you can also notice, the pinout of the SPI0 interface is identical for the en
   <tr>
     <td><img src="https://user-images.githubusercontent.com/69086569/216763154-ca4aa8fa-5855-43c1-86c2-d401010de675.png"/></td>
     <td><img src="https://user-images.githubusercontent.com/69086569/231207350-a670bfea-a96d-4d21-9e8f-f2ca027105da.png"/></td>
-  </tr>
-  <tr>
-    <td><img src="https://github.com/awawa-dev/HyperSPI/assets/69086569/170f5718-df88-4ef2-9ed8-7d92d913aeec"/></td>
-    <td><img src="https://github.com/awawa-dev/HyperSPI/assets/69086569/9235c689-062e-4c62-b632-8c506b0e2e97"/></td>
-  </tr>
+  </tr> 
 </table>
 
 # Example of supported boards

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ As you can also notice, the pinout of the SPI0 interface is identical for the en
 <img src="https://user-images.githubusercontent.com/69086569/207587620-1c4c53c8-426c-486e-a6d9-d429fd1b050d.png" width="250"/><img src="https://user-images.githubusercontent.com/69086569/207587635-b7816329-0e29-47ee-a75a-bc6c41cdc51f.png" width="250"/>
 </p>
 
-## Default pinout (can be changed for esp32 and esp32-s2)
+## Default pinout (can be changed for esp32, esp32-s2 and rp2040 Pico)
   
-|    PINOUT   |  ESP8266  |   ESP32   | ESP32-S2 lolin mini| Pico (rp2040)
+|    PINOUT   |  ESP8266  |   ESP32   | ESP32-S2 | Pico (rp2040)
 |-------------|-----------|-----------|-----------|-----------|
 | Clock (SCK) | GPIO 14   | GPIO 18   | GPIO 7    | GPIO 2    |
 | Data (MOSI) | GPIO 13   | GPIO 23   | GPIO 11   | GPIO 4    |
@@ -105,12 +105,23 @@ Or use `esptool.py` e.g.
 For **RGBW LED strip** like RGBW SK6812 NEUTRAL white choose: *hyperspi_..._SK6812_RGBW_NEUTRAL.bin*  
 For **RGBW LED strip** like RGBW SK6812 COLD white choose: *hyperspi_..._SK6812_RGBW_COLD.bin*  
 For **RGB LED strip** like WS8212b or RGB SK6812 variant choose: *hyperspi_..._WS281x_RGB.bin*  
+
+## Flashing Pico boards
+
+It's very easy and you don't need any special flasher.  
+
+Put your Pico board into DFU mode:  
+* If your Pico board has only one button (`boot`) then press & hold it and connect the board to the USB port. Then you can release the button.
+* If your Pico board has two buttons, connect it to the USB port. Then press & hold `boot` and `reset` buttons, then release `reset` and next release `boot` button.  
+
+In the system file explorer you should find new drive (e.g. called `RPI-RP2` drive) exposed by the Pico board. Drag & drop (or copy) the selected firmware to this drive. 
+The Pico will reset automaticly after the upload and after few seconds it will be ready to use.
   
 # Software configuration (HyperHDR v17 and above)
 
 **In HyperHDR `Image Processing→Smoothing→Update frequency` you should do not exceed the maximum capacity of the device. Read more here: [testing performance](https://github.com/awawa-dev/HyperSPI#performance-output)**
 
-Select esp8266 protocol for ESP proprietary SPI protocol, esp32 for ESP32 boards or 'standard' for other devices.    
+Select esp8266 protocol for ESP proprietary SPI protocol, esp32 for ESP32 boards, `rp2040 (Pico)` for Pico boards or 'standard' for other devices.    
 Make sure you set "Refresh time" to zero, "Baudrate" should be set to high but realistic value like ```25 000 000```.  
 Enabling "White channel calibration" is optional, if you want to fine tune the white channel balance of your sk6812 RGBW LED strip.
   
@@ -143,11 +154,23 @@ Enabling "White channel calibration" is optional, if you want to fine tune the w
 | 900LEDs RGBW<br>Refresh rate/continues output=22Hz  |          22         |
 
 # Compiling
-  
+
+## ESP8266 / ESP32
+
 Currently we use PlatformIO to compile the project. Install [Visual Studio Code](https://code.visualstudio.com/) and add [PlatformIO plugin](https://platformio.org/).
 This environment will take care of everything and compile the firmware for you. Low-level LED strip support is provided by my highly optimizated (pre-fill I2S DMA modes, turbo I2S parallel mode for up to 2 segments etc) version of Neopixelbus library: [link](https://github.com/awawa-dev/NeoPixelBus).
 
-But there is also an alternative and an easier way. Just fork the project and enable its Github Action. Use the online editor to make changes to the ```platformio.ini``` file, for example change default pin-outs or enable multi-segments support, and save it. Github Action will compile new firmware automatically in the Artifacts archive. It has never been so easy! **Just remember to follow the steps in the correct order otherwise the Github Action may not be triggered the first time after saving the changes.**
+## Pico rp2040
+
+Use Pico SDO and Visual Code to open ```rp2040``` folder. Edit ```rp2040\CMakeLists.txt``` configuration file if you need to apply changes.
+
+## Github Action
+
+But there is also an alternative and an easier way. Just fork the project and enable its Github Action. Use the online editor to make changes:
+- esp8266/ESP32 boards: to the ```platformio.ini``` file
+- rp2040 Pico boards: to the ```rp2040\CMakeLists.txt``` file
+
+for example change default pin-outs or enable multi-segments support, and save it. Github Action will compile new firmware automatically in the Artifacts archive. It has never been so easy! **Just remember to follow the steps in the correct order otherwise the Github Action may not be triggered the first time after saving the changes.**
 
 Tutorial: https://github.com/awawa-dev/HyperSPI/wiki
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ For **RGB LED strip** like WS8212b or RGB SK6812 variant choose: *hyperspi_..._W
 
 It's very easy and you don't need any special flasher.  
 
+Use firmware from the `PicoRp2040Boards.zip` archive. Adafruit boards have their own custom firmware package inside the archive: `Adafruit_ItsyBitsy_RP2040.zip` and `Adafruit_Feather_RP2040_Scorpio.zip`
+
 Put your Pico board into DFU mode:  
 * If your Pico board has only one button (`boot`) then press & hold it and connect the board to the USB port. Then you can release the button.
 * If your Pico board has two buttons, connect it to the USB port. Then press & hold `boot` and `reset` buttons, then release `reset` and next release `boot` button.  

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ As you can also notice, the pinout of the SPI0 interface is identical for the en
 
 ## Default pinout (can be changed for esp32, esp32-s2 and rp2040 Pico)
   
-|    PINOUT   |  ESP8266  |   ESP32   | ESP32-S2 | Pico (rp2040)
-|-------------|-----------|-----------|-----------|-----------|
-| Clock (SCK) | GPIO 14   | GPIO 18   | GPIO 7    | GPIO 2    |
-| Data (MOSI) | GPIO 13   | GPIO 23   | GPIO 11   | GPIO 4    |
-| SPI Chip Select(e.g. CE0) | not used    | GPIO 5    | GPIO 12   | GPIO 5    |
-| GROUND      | mandatory | mandatory | mandatory | mandatory |
-| LED output  | GPIO 2    | GPIO 2    | GPIO 2    | GPIO 14 |
+|    PINOUT   |  ESP8266  |   ESP32   | ESP32-S2 | Pico (rp2040) | Adafruit rp2040<br/>Scoprio & ItsyBitsy
+|-------------|-----------|-----------|-----------|-----------|-----------|
+| Clock (SCK) | GPIO 14   | GPIO 18   | GPIO 7    | GPIO 2    | GPIO 26 (A0) |
+| Data (MOSI) | GPIO 13   | GPIO 23   | GPIO 11   | GPIO 4    | GPIO 28 (A2) |
+| SPI Chip Select(e.g. CE0) | not used    | GPIO 5    | GPIO 12   | GPIO 5    | GPIO 29 (A3) |
+| GROUND      | mandatory | mandatory | mandatory | mandatory | mandatory |
+| LED output  | GPIO 2    | GPIO 2    | GPIO 2    | GPIO 14 | GPIO16 / GPIO14 |
 
 > [!CAUTION]
 > The ground connection between both GPIOs is as important as the other SPI data connections. The ground cable should be of a similar length as them and run directly next to them.
@@ -162,7 +162,7 @@ This environment will take care of everything and compile the firmware for you. 
 
 ## Pico rp2040
 
-Use Pico SDO and Visual Code to open ```rp2040``` folder. Edit ```rp2040\CMakeLists.txt``` configuration file if you need to apply changes.
+Use Pico SDK and Visual Code to open ```rp2040``` folder. Edit ```rp2040\CMakeLists.txt``` configuration file if you need to apply changes.
 
 ## Github Action
 
@@ -174,7 +174,9 @@ for example change default pin-outs or enable multi-segments support, and save i
 
 Tutorial: https://github.com/awawa-dev/HyperSPI/wiki
 
-# Multi-Segment Wiring (ESP32 and ESP32-S2 only)
+# Multi-Segment Wiring (ESP32, ESP32-S2 and Pico rp2040 boards only)
+
+## ESP32
 
 Using parallel multi-segment allows you to double your Neopixel (e.g. sk6812 RGBW) LED strip refresh rate by dividing it into two smaller equal parts. Both smaller segments are perfectly in sync so you don't need to worry about it. Proposed example of building a multisegment:
 - Divide a long or dense strip of LEDs into 2 smaller equal parts. So `SECOND_SEGMENT_START_INDEX` in the HyperSPI firmware is the total number of LEDs divided by 2.
@@ -199,6 +201,10 @@ build_flags = -DNEOPIXEL_RGB -DDATA_PIN=2 ${env.build_flags} -DSECOND_SEGMENT_ST
 ```
 Implementation example:
 - The diagram of the board for WS2812b/SK6812 including ESP32 and the SN74AHCT125N 74AHCT125 [level shifter](https://github.com/awawa-dev/HyperHDR/wiki/Level-Shifter).
+
+# Pico rp2040
+
+Edit ```rp2040\CMakeLists.txt``` file and recompile the project.
 
 ![HyperSPI](https://user-images.githubusercontent.com/85223482/222923979-f344349a-1f8b-4195-94ca-51721923359e.png)
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ As you can also notice, the pinout of the SPI0 interface is identical for the en
 
 # Example of supported boards
 
+<p align="center">
+<b>Adafruit RP2040 Scorpio and ItsyBitsy with built-in level shifter (recommended!)</b><br/>  
+<img src="https://github.com/awawa-dev/HyperSPI/assets/69086569/c7ef2768-357e-47ca-aa1c-543769eeb360" width="250" /><img src="https://github.com/awawa-dev/HyperSPI/assets/69086569/3e55948d-fd3d-44cb-908c-9aad8ce2715d" width="250" />
+</p>
 
 <p align="center">
 <b>Esp8266 Wemos D1 mini (CH340) and Wemos D1 mini pro (CP2104)</b><br/>
@@ -66,7 +70,7 @@ As you can also notice, the pinout of the SPI0 interface is identical for the en
 
 ## Default pinout (can be changed for esp32, esp32-s2 and rp2040 Pico)
   
-|    PINOUT   |  ESP8266  |   ESP32   | ESP32-S2 | Pico (rp2040) | Adafruit rp2040<br/>Scoprio & ItsyBitsy
+|    PINOUT   |  ESP8266  |   ESP32   | ESP32-S2 | Pico (rp2040) | Adafruit rp2040<br/>Scorpio & ItsyBitsy
 |-------------|-----------|-----------|-----------|-----------|-----------|
 | Clock (SCK) | GPIO 14   | GPIO 18   | GPIO 7    | GPIO 2    | GPIO 26 (A0) |
 | Data (MOSI) | GPIO 13   | GPIO 23   | GPIO 11   | GPIO 4    | GPIO 28 (A2) |

--- a/rp2040/CMakeLists.txt
+++ b/rp2040/CMakeLists.txt
@@ -23,6 +23,39 @@ set(OUTPUT_SPI_INTERFACE spi0)
 
 # User configuration section ends here
 # Usually you don't need to change anything below this section
+
+if(NOT CMAKE_HOST_WIN32)
+	string(ASCII 27 EscChar)
+	set(ColorReset  "${EscChar}[m")
+	set(GreenColor  "${EscChar}[32m")
+	set(YellowColor "${EscChar}[33m")	
+endif()
+
+if (OVERRIDE_DATA_PIN)
+	set(OUTPUT_DATA_PIN ${OVERRIDE_DATA_PIN})
+	message( STATUS "${YellowColor}Overriding output Neopixel Data GPIO: ${OUTPUT_DATA_PIN}${ColorReset}")
+endif()
+
+if (OVERRIDE_SPI_DATA_PIN)
+	set(OUTPUT_SPI_DATA_PIN ${OVERRIDE_SPI_DATA_PIN})
+	message( STATUS "${YellowColor}Overriding input SPI Data GPIO: ${OUTPUT_SPI_DATA_PIN}${ColorReset}")
+endif()
+
+if (OVERRIDE_SPI_CLOCK_PIN)
+	set(OUTPUT_SPI_CLOCK_PIN ${OVERRIDE_SPI_CLOCK_PIN})
+	message( STATUS "${YellowColor}Overriding input SPI Clock GPIO: ${OUTPUT_SPI_CLOCK_PIN}${ColorReset}")
+endif()
+
+if (OVERRIDE_SPI_CHIP_SELECT)
+	set(OUTPUT_SPI_CHIP_SELECT ${OVERRIDE_SPI_CHIP_SELECT})
+	message( STATUS "${YellowColor}Overriding input SPI chip select GPIO: ${OUTPUT_SPI_CHIP_SELECT}${ColorReset}")
+endif()
+
+if (OVERRIDE_SPI_INTERFACE)
+	set(OUTPUT_SPI_INTERFACE ${OVERRIDE_SPI_INTERFACE})
+	message( STATUS "${YellowColor}Overriding input SPI Interface: ${OUTPUT_SPI_INTERFACE}${ColorReset}")
+endif()
+
 cmake_minimum_required(VERSION 3.13)
 
 set(PICO_SDK_PATH ${CMAKE_CURRENT_SOURCE_DIR}/HyperSerialPico/sdk/pico)


### PR DESCRIPTION
### Adafruit ItsyBitsy RP2040
Output:
Neopixel is using GPIO14(OUTPUT_DATA_PIN) on output D5.

SPI input:
**SPI MOSI->MISO is GPIO28 (A2)**
SPI SCK is GPIO26 (A0)
SPI CHIP_SELECT is GPIO29 (A3)
SPI interface is spi1

### Adafruit Feather RP2040 Scorpio
Output:
Neopixel is using GPIO16(OUTPUT_DATA_PIN) on output 0.

SPI input:
**SPI MOSI->MISO is GPIO28 (A2)**
SPI SCK is GPIO26 (A0)
SPI CHIP_SELECT is GPIO29 (A3)
SPI interface is spi1
